### PR TITLE
Jenkinsfile: Check env in mirror sync

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -173,7 +173,7 @@ pipeline {
 
 								script {
 									catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
-										if (! env.CHANGE_TARGET && ! env.PR_BRANCHES && env.YOCTO_VERSION == env.BRANCH_NAME) {
+										if (env.CHANGE_TARGET == null && env.PR_BRANCHES == null && env.YOCTO_VERSION == env.BRANCH_NAME) {
 											lock ('sync-mirror') {
 												script {
 													catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {


### PR DESCRIPTION
This commit adapts the Jenkinsfile such that env.CHANGE_TARGET and env.PR_BRANCHES is checked to avoid exceptions due to properties not set by Jenkins.