### PR TITLE
Jenkinsfile: Fixed GYROID_ARCH paramter list for arm32

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
 	}
 
 	parameters {
-		choice(name: 'GYROID_ARCH', choices: ['x86', 'arm', 'arm64'], description: 'GyroidOS Target Architecture')
+		choice(name: 'GYROID_ARCH', choices: ['x86', 'arm32', 'arm64'], description: 'GyroidOS Target Architecture')
 		choice(name: 'GYROID_MACHINE', choices: ['genericx86-64', 'apalis-imx8', 'raspberrypi3-64', 'raspberrypi2'], description: 'GyroidOS Target Machine (Must be compatible with GYROID_ARCH!)')
 		string(name: 'PR_BRANCHES', defaultValue: '', description: 'Comma separated list of pull request branches (e.g. meta-trustx=PR-177,meta-trustx-nxp=PR-13,gyroidos_build=PR-97)')
 		choice(name: 'BUILD_INSTALLER', choices: ['y', 'n'], description: 'Build the GyroidOS installer (x86 only)')


### PR DESCRIPTION
Our manifest files are called yocto-<$GYROID_ARCH>-<board>.xml. For arm 32bit based boards we use arm32 and not just arm. Thus we also need to set the selector from arm to arm32.