### PR TITLE
Jenkinsfile: Reduced extra space from 10 GB to 3GB

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -150,7 +150,7 @@ pipeline {
 								cat conf/local.conf
 
 
-								echo 'TRUSTME_DATAPART_EXTRA_SPACE="10000"' >> conf/local.conf
+								echo 'TRUSTME_DATAPART_EXTRA_SPACE="3000"' >> conf/local.conf
 
 								bitbake trustx-cml-initramfs multiconfig:container:trustx-core
 								bitbake trustx-cml


### PR DESCRIPTION
For arm builds where the image is copied to sd cards with smaller sizes and low speed, the 10GB were a problem. Thus, we reduce this to 3GB which allows enough space for our pipeline tests and also allow smaller target sd cards.