### PR TITLE
Jenkinsfile: archive cml_updates kernel tarball

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -216,7 +216,7 @@ pipeline {
 									}
 								}
 
-								archiveArtifacts artifacts: 'out-**/tmp/deploy/images/**/trustme_image/trustmeimage.img.xz, out-**/tmp/deploy/images/**/trustme_image/trustmeinstaller.img.xz, out-**/test_certificates/**', fingerprint: true
+								archiveArtifacts artifacts: 'out-**/tmp/deploy/images/**/trustme_image/trustmeimage.img.xz, out-**/tmp/deploy/images/**/trustme_image/trustmeinstaller.img.xz, out-**/test_certificates/**, out-**/tmp/deploy/images/**/cml_updates/kernel-**.tar', fingerprint: true
 							}
 						}
 					}


### PR DESCRIPTION
Added the kernel tarball in cml_updates folder to artifacts. This allows quick download of cml updates only without the need to download and extract the whole 'trustmeimage.img'.