### PR TITLE
Jenkinsfile: increase number of kept builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,9 @@
 pipeline {
 	agent any
-	options { checkoutToSubdirectory('.manifests') }
+	options {
+		checkoutToSubdirectory('.manifests')
+		buildDiscarder(logRotator(numToKeepStr: '25'))
+	}
 
 	environment {
 		YOCTO_VERSION = 'kirkstone'


### PR DESCRIPTION
With the new pipeline model 10 kept builds are sometimes too few as they are discarded quickly with many PRs. Let's try with 25.