### PR TITLE
Jenkinsfile: Avoid ssh port clashes when building PRs simultaneously

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -274,7 +274,8 @@ pipeline {
 									if [ -z "${CHANGE_TARGET}" ];then
 										echo "No PR-Build, using fixed port numbers"
 
-										export ssh_port="222${port_buildtype}"
+										port_buildnr="$(expr $(printf "%d\n" "${BUILD_NUMBER}") % 100)"
+										export ssh_port="22${port_buildnr}${port_buildtype}"
 										export vnc_display="4${port_buildtype}"
 									else
 										echo "PR-Build, using port numbers based on PR"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,6 @@
 pipeline {
 	agent any
-	options {
-		checkoutToSubdirectory('.manifests')
-		buildDiscarder(logRotator(numToKeepStr: '25'))
-	}
+	options { checkoutToSubdirectory('.manifests') }
 
 	environment {
 		YOCTO_VERSION = 'kirkstone'


### PR DESCRIPTION
Since the main ogig was moved from cml repository to this one. The CHANGE_TARGET is not set for PRs in other repos. Thus, if building several PRs to, e.g., the cml repo, SSH ports during parallel integration tests could have been clashed. Using the BUILD_NUMBER from this repo should avoid that.