### PR TITLE
Run integration tests in container + proper user initialization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,10 @@ RUN apt-get update && apt-get install -y python-crypto python3-crypto
 
 WORKDIR "/opt/ws-yocto/"
 
+ARG BUILDUSER
+
+RUN if ! [ -z "${BUILDUSER}" ];then echo "Preparing container home directory for user ${BUILDUSER}" && adduser builder --disabled-password --uid "${BUILDUSER}" --gecos ""; else echo "Docker build argument BUILDUSER not supplied, leaving unconfigured...";fi
+
 #COPY ./entrypoint.sh /usr/local/bin/entrypoint.sh
 
 #ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@ pipeline {
 
 	environment {
 		YOCTO_VERSION = 'kirkstone'
+		BUILDUSER = "${sh(script:'id -u', returnStdout: true).trim()}"
 		KVM_GID = "${sh(script:'getent group kvm | cut -d: -f3', returnStdout: true).trim()}"
 	}
 
@@ -95,6 +96,7 @@ pipeline {
 						agent {
 							dockerfile {
 								dir ".manifests"
+								additionalBuildArgs '--build-arg=BUILDUSER=$BUILDUSER'
 								args '--entrypoint=\'\' -v /yocto_mirror/${YOCTO_VERSION}/${GYROID_ARCH}/sources:/source_mirror -v /yocto_mirror/${YOCTO_VERSION}/${GYROID_ARCH}/sstate-cache:/sstate_mirror --env BUILDNODE="${env.NODE_NAME}"'
 								reuseNode false
 							}
@@ -245,6 +247,7 @@ pipeline {
 						agent {
 							dockerfile {
 								dir ".manifests"
+								additionalBuildArgs '--build-arg=BUILDUSER=$BUILDUSER'
 								args '--entrypoint=\'\' --device=/dev/kvm --group-add=$KVM_GID -p 2222'
 								label 'worker'
 							}


### PR DESCRIPTION
This PR adapts the' Intgration Test' stage s.t. it is executed in a container to avoid name and port clashes during concurrent builds. Also, proper user initialization for the build user is done as in the Dockerfile in the gyroidos_build repo at yocto/docker/Dockerfile