### PR TITLE
Jenkinsfile: Increase extra image space

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -152,8 +152,7 @@ pipeline {
 
 								cat conf/local.conf
 
-
-								echo 'TRUSTME_DATAPART_EXTRA_SPACE="3000"' >> conf/local.conf
+								echo 'TRUSTME_DATAPART_EXTRA_SPACE="6144"' >> conf/local.conf
 
 								bitbake trustx-cml-initramfs multiconfig:container:trustx-core
 								bitbake trustx-cml


### PR DESCRIPTION
The extended tests in gyroidos/cml#415 create more containers than before. Thus, additional space is needed for the tests to run correctly.