### PR TITLE
Jenkinsfile: Store CML logs after token test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -328,7 +328,7 @@ pipeline {
 					}
 
 					echo "Archiving CML logs"
-					archiveArtifacts artifacts: 'out-schsm/cml_logs', fingerprint: true, allowEmptyArchive: true
+					archiveArtifacts artifacts: 'out-**/cml_logs/**, cml_logs/**', fingerprint: true, allowEmptyArchive: true
 
 					script {
 						if ('FAILURE' == currentBuild.result) {


### PR DESCRIPTION
This commit fixes the Jenkinsfile s.t. CML logs are properly stored in the build Jenkins build artifacts for the integration tests with schsm support.