### PR TITLE
Dockerfile: Add libcap-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update -y && apt-get install -y \
 	libprotobuf-c-dev \
 	protobuf-compiler \
 	protobuf-c-compiler \
+	libcap-dev \
 # CI
 	libssl-dev \
 	libcap-dev \


### PR DESCRIPTION
This commit adds libcap-dev to the Dockerfile as sys/capability.h is required for the CML build since gyroidos/cml#443