### PR TITLE
Jenkinsfile: Increase extra space of image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -247,7 +247,7 @@ pipeline {
 								echo "BB_SIGNATURE_HANDLER = \\\"OEBasicHash\\\"" >> conf/local.conf
 								echo "BB_HASHSERVE = \\\"\\\"" >> conf/local.conf
 
-								echo 'TRUSTME_DATAPART_EXTRA_SPACE="3000"' >> conf/local.conf
+								echo 'TRUSTME_DATAPART_EXTRA_SPACE="5000"' >> conf/local.conf
 
 								if [[ "apalis-imx8 tqma8mpxl" =~ "${GYROID_MACHINE}" ]]; then
 									# when building for NXP machines you have to accept the Freescale EULA


### PR DESCRIPTION
For guestos update tests we need a little more space on '/data/cml/operatingsystems', thus increase extra space on overall image.