### PR TITLE
tree-wide: renamed repos meta-trustx* to meta-gyroidos*

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
 		string(name: 'CI_LIB_VERSION', defaultValue: 'main', description: 'Version of the gyroidos_ci_common library to be used (e.g. main or pull/<pr_num>/merge)')
 		choice(name: 'GYROID_ARCH', choices: ['x86', 'arm32', 'arm64'], description: 'GyroidOS Target Architecture')
 		choice(name: 'GYROID_MACHINE', choices: ['genericx86-64', 'apalis-imx8', 'raspberrypi2', 'raspberrypi3-64', 'raspberrypi4-64', 'raspberrypi5', 'tqma8mpxl'], description: 'GyroidOS Target Machine (Must be compatible with GYROID_ARCH!)')
-		string(name: 'PR_BRANCHES', defaultValue: '', description: 'Comma separated list of pull request branches (e.g. meta-trustx=PR-177,meta-trustx-nxp=PR-13,gyroidos_build=PR-97)')
+		string(name: 'PR_BRANCHES', defaultValue: '', description: 'Comma separated list of pull request branches (e.g. meta-gyroidos=PR-177,meta-gyroidos-nxp=PR-13,gyroidos_build=PR-97)')
 		choice(name: 'BUILD_INSTALLER', choices: ['n', 'y'], description: 'Build the GyroidOS installer (x86 only)')
 		choice(name: 'REBUILD_PREVIOUS', choices: ['n', 'y'], description: 'Rebuild selected, previous build instead of just reusing image from artifacts')
 		buildSelector defaultSelector: specific('${BUILD_NUMBER}'), name: 'BUILDSELECTOR', description: 'Image to perform integration tests on. Changing the default value skips the image build.'
@@ -250,7 +250,7 @@ EOF
 					/*TODO;Skipped for now*/
 					when {
 						expression {
-							/*If branch trustx master and comes from main repo?*/
+							/*If branch gyroidos master and comes from main repo?*/
 							return false
 						}
 					}
@@ -264,7 +264,7 @@ EOF
 					/*TODO;Skipped for now*/
 					when {
 						expression {
-							/*If branch trustx master and comes from main repo?*/
+							/*If branch gyroidos master and comes from main repo?*/
 							return false
 						}
 					}
@@ -280,7 +280,7 @@ EOF
 			/*TODO;Skipped for now*/
 			when {
 				expression {
-					/*If branch trustx master and comes from main repo?*/
+					/*If branch gyroidos master and comes from main repo?*/
 					return false
 				}
 			}

--- a/gyroidos-base.xml
+++ b/gyroidos-base.xml
@@ -26,7 +26,7 @@
      <linkfile src="yocto/init_ws_ids.sh" dest="init_ws.sh" />
   </project>
   <project path="gyroidos/cml" name="cml" remote="gyroidos" />
-  <project path="meta-trustx" name="meta-trustx" remote="gyroidos" />
+  <project path="meta-gyroidos" name="meta-gyroidos" remote="gyroidos" />
   <project path="meta-tmedbg" name="meta-tmedbg" remote="gyroidos" />
 
   <!-- YOCTO UTILITIES/FEATURES -->

--- a/yocto-arm64-tqma8mpxl.xml
+++ b/yocto-arm64-tqma8mpxl.xml
@@ -11,7 +11,7 @@
     fetch="https://github.com/tq-systems"/>
 
   <!-- TARGET SPECIFICS -->
-  <project path="meta-trustx-nxp" name="meta-trustx-nxp" remote="gyroidos" />
+  <project path="meta-gyroidos-nxp" name="meta-gyroidos-nxp" remote="gyroidos" />
 
   <!-- Freescale -->
   <project path="meta-freescale" name="meta-freescale" remote="yocto" />

--- a/yocto-raspberrypi.xml
+++ b/yocto-raspberrypi.xml
@@ -4,6 +4,6 @@
   <include name="gyroidos-base.xml" />
 
   <!-- TARGET SPECIFICS -->
-  <project path="meta-trustx-rpi" name="meta-trustx-rpi" remote="gyroidos" />
+  <project path="meta-gyroidos-rpi" name="meta-gyroidos-rpi" remote="gyroidos" />
   <project path="meta-raspberrypi" name="meta-raspberrypi" />
 </manifest>

--- a/yocto-toradex.xml
+++ b/yocto-toradex.xml
@@ -11,7 +11,7 @@
     fetch="https://git.toradex.com"/>
 
   <!-- TARGET SPECIFICS -->
-  <project path="meta-trustx-nxp" name="meta-trustx-nxp" remote="gyroidos" />
+  <project path="meta-gyroidos-nxp" name="meta-gyroidos-nxp" remote="gyroidos" />
 
   <!-- Freescale -->
   <project path="meta-freescale" name="meta-freescale" remote="yocto" />

--- a/yocto-x86-genericx86-64.xml
+++ b/yocto-x86-genericx86-64.xml
@@ -4,5 +4,5 @@
   <include name="gyroidos-base.xml" />
 
   <!-- TARGET SPECIFICS -->
-  <project path="meta-trustx-intel" name="meta-trustx-intel" remote="gyroidos" />
+  <project path="meta-gyroidos-intel" name="meta-gyroidos-intel" remote="gyroidos" />
 </manifest>


### PR DESCRIPTION
On github the upstream repos where change from old codename trustx to project name gyroidos. Thus all meta-trustx* repos are named meta-gyroidos*. We changed this in all the manifests and Jenkinsfile, too.