### PR TITLE
yocto-riscv-beaglev-fire: Pin polarfire bsp revision

### DIFF
--- a/yocto-riscv-beaglev-fire.xml
+++ b/yocto-riscv-beaglev-fire.xml
@@ -5,6 +5,7 @@
 
   <!-- ADDITIONAL REMOTES -->
   <remote  name="polarfire"
+    revision="2024.09"
     fetch="https://github.com/polarfire-soc"/>
 
   <!-- TARGET SPECIFICS -->


### PR DESCRIPTION
Rolling head polarfire layer dropped support for kirstone. Pin to 2024.09 until we move to scarthgap.